### PR TITLE
Updates needed for rebuilding docker image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "miqScoreNGSReadCountPublic"]
 	path = miqScoreNGSReadCountPublic
-	url = git@github.com:Zymo-Research/miqScoreNGSReadCountPublic.git
+	url = https://github.com/Zymo-Research/miqScoreNGSReadCountPublic.git
 [submodule "miqScoreShotgunPublicSupport"]
 	path = miqScoreShotgunPublicSupport
 	url = https://github.com/Zymo-Research/miqScoreShotgunPublicSupport.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.7
+FROM python:3.7
 
 MAINTAINER Michael M. Weinstein, Zymo Research
 LABEL version="0.0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY ./requirements.txt /opt/referenceBuild
 
 #doing expensive and unlikely to change build processes here to speed up testing builds
 RUN cd /opt/referenceBuild/ && \
+    pip3 install -U pip && \
     pip3 install -r requirements.txt && \
     cd reference && \
     echo "Indexing standard genome" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /
 
 RUN apt-get update && \
     apt install -y autoconf automake make gcc perl zlib1g-dev libbz2-dev liblzma-dev libssl-dev libncurses5-dev && \
+    apt autoclean && \
+    apt autoremove -y && \
     cd tmp && \
     wget https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
     tar -xjvf samtools-1.9.tar.bz2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /tmp &&\
     tar -xvf v0.7.16.tar.gz && \
     rm v0.7.16.tar.gz && \
     cd bwa-0.7.16 &&\
-    make && \
+    make CC='gcc -fcommon' && \
     cd /tmp && \
     cp -r bwa-0.7.16 /opt/ && \
     rm -rf bwa-0.7.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.13.1
-scipy==1.2.1
-matplotlib==3.0.2
+numpy==1.17.0
+scipy==1.7.3
+matplotlib==3.5
 pysam==0.15.3


### PR DESCRIPTION
We needed to rebuild the docker image to run some containers and found a few changes were needed.

Github deprecated anonymous cloning using `git@github.com:user/project.git` urls. So replaced it with the https equivalent for the submodule.

The `python:3.6` base image is not supported anymore because the base operating system is _EOL_. So replaced it with `python:3.7` which I hope will not mean any big changes in behaviour python-wise. The switch of base image comes with an upgraded `gcc` which makes `bwa` building unhappy. So I used an explicit option for `gcc` during `make`. That is a known issue with `bwa` and stole the solution from `bwa` `github` issues. Also with the switch to python I had to upgrade versions of some of your python dependencies. I tried to upgrade things just enough to keep things compatible.

Also added some cleaning for `apt` to try to reduce the resulting image. That should have no impact in functionality but help to produce a slightly smaller image. And a `pip` update which is usually good to have.

We used the resulting image a couple of times and seems things are happy. But probably checking with some edge cases would be a good idea.

My neighbours here at Sanger are suggesting upgrading to a more recent `samtools`. But that will likely produce some small variations in output. So probably best to have a release with as few changes as possible and then make a release which may have breaking changes.
